### PR TITLE
스캐너·파서·인터프리터 기본 테스트 추가

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,9 @@ module github.com/ariyn/lox_interpreter
 
 go 1.22
 
-require github.com/stretchr/testify v1.9.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -1,0 +1,27 @@
+package lox_interpreter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpreter_Evaluate(t *testing.T) {
+	src := "var a = 1 + 2;"
+	scanner := NewScanner(src)
+	tokens, err := scanner.ScanTokens()
+	require.NoError(t, err)
+
+	parser := NewParser(tokens)
+	stmts, err := parser.Parse()
+	require.NoError(t, err)
+
+	interpreter := NewInterpreter(nil)
+	_, err = interpreter.Interpret(stmts)
+	require.NoError(t, err)
+
+	val, ok := interpreter.Env.Values["a"]
+	require.True(t, ok)
+	assert.Equal(t, 3.0, val)
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,28 @@
+package lox_interpreter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser_ParseVarDeclaration(t *testing.T) {
+	src := "var a = 123;"
+	scanner := NewScanner(src)
+	tokens, err := scanner.ScanTokens()
+	require.NoError(t, err)
+
+	parser := NewParser(tokens)
+	stmts, err := parser.Parse()
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	varStmt, ok := stmts[0].(*VarStmt)
+	require.True(t, ok)
+	assert.Equal(t, "a", varStmt.name.Lexeme)
+
+	lit, ok := varStmt.initializer.(*LiteralExpr)
+	require.True(t, ok)
+	assert.Equal(t, 123.0, lit.value)
+}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,0 +1,26 @@
+package lox_interpreter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanner_ScanTokens(t *testing.T) {
+	src := "var a = 123;"
+	scanner := NewScanner(src)
+	tokens, err := scanner.ScanTokens()
+	require.NoError(t, err)
+	require.Len(t, tokens, 6)
+
+	expectedTypes := []TokenType{VAR, IDENTIFIER, EQUAL, NUMBER, SEMICOLON, EOF}
+	for i, typ := range expectedTypes {
+		assert.Equal(t, typ, tokens[i].Type)
+	}
+
+	assert.Equal(t, "var", tokens[0].Lexeme)
+	assert.Equal(t, "a", tokens[1].Lexeme)
+	assert.Equal(t, "123", tokens[3].Lexeme)
+	assert.Equal(t, 123.0, tokens[3].Literal)
+}


### PR DESCRIPTION
## 요약
- 스캐너가 변수 선언을 올바르게 토큰화하는지 검증하는 테스트 추가
- 파서가 변수 선언을 AST로 변환하는지 확인하는 테스트 추가
- 인터프리터가 산술 연산과 변수 저장을 수행하는지 확인하는 테스트 추가

## 테스트
- `go vet ./...`
- `go test -v`


------
https://chatgpt.com/codex/tasks/task_e_689b47e27648832384d4bd550420e4e6