### PR TITLE
Handle unrecognized operators in interpreter

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -436,9 +436,9 @@ func (i *Interpreter) VisitUnaryExpr(expr *UnaryExpr) (interface{}, error) {
 		return -right.(float64), nil
 	case BANG:
 		return !i.isTruthy(right), nil
+	default:
+		return nil, NewRuntimeError(expr.operator, fmt.Sprintf("Unknown unary operator %s", expr.operator.Lexeme), i.callStack)
 	}
-
-	return nil, nil // TODO: return error
 }
 
 func (i *Interpreter) VisitCallExpr(expr *CallExpr) (interface{}, error) {
@@ -602,9 +602,9 @@ func (i *Interpreter) VisitBinaryExpr(expr *BinaryExpr) (interface{}, error) {
 		return left == right, nil
 	case BANG_EQUAL:
 		return left != right, nil
+	default:
+		return nil, NewRuntimeError(expr.operator, fmt.Sprintf("Unknown binary operator %s", expr.operator.Lexeme), i.callStack)
 	}
-
-	return nil, nil // TODO: return error
 }
 
 func (i *Interpreter) VisitLiteralExpr(expr *LiteralExpr) (interface{}, error) {


### PR DESCRIPTION
## Summary
- ensure VisitUnaryExpr reports a runtime error for unknown operators
- ensure VisitBinaryExpr reports a runtime error for unknown operators

## Testing
- `go vet ./...` *(fails: fmt.Fprintln arg list ends with redundant newline, Token struct literal uses unkeyed fields)*
- `go test ./...` *(fails: build failed)*

------
https://chatgpt.com/codex/tasks/task_e_689b47f201748323be9effaf2e452558